### PR TITLE
Update SF2HF Discord Link

### DIFF
--- a/motd.json
+++ b/motd.json
@@ -471,7 +471,7 @@
     },
     {
       "gameid": "sf2hf",
-      "motd": "Discord: https://discord.gg/Zq7aS6mDUe\n"
+      "motd": "Discord: https://discord.gg/sf2hf\n"
     },
     {
       "gameid": "ringdest",


### PR DESCRIPTION
The SF2HF discord invite link has a new URL.