### PR TITLE
Update motd.json SF2HF Discord Link

### DIFF
--- a/motd.json
+++ b/motd.json
@@ -471,7 +471,7 @@
     },
     {
       "gameid": "sf2hf",
-      "motd": "Discord: https://discord.gg/sf2hf\n"
+      "motd": "Discord: https://discord.gg/Zq7aS6mDUe\n"
     },
     {
       "gameid": "ringdest",


### PR DESCRIPTION
It was brought to my attention that the "discord.gg/sf2hf" invite link is a "custom invite link" that expires when the server boosts run out, meaning people can't join off of it from the FC2 HF lobby if the server isn't currently boosted. I've instead switched it back to a normal permanent invite link. I apologize for the error, I wasn't aware of the limitation.