### PR TITLE
SMS: Correcting the wiki link

### DIFF
--- a/motd.json
+++ b/motd.json
@@ -691,7 +691,7 @@
     },
     {
       "gameid": "snes_sailorsj",
-      "motd": "Game Info: https://newchallenger.net/w/index.php?title=Sailor_Moon_Fighter_S\nDiscord: http://moonlightfight.com\n"
+      "motd": "Game Info: https://newchallenger.net/w/index.php?title=Sailor_Moon_S\nDiscord: http://moonlightfight.com\n"
     },
     {
       "gameid": "snes_sailorsbze",


### PR DESCRIPTION
The wiki link for SMS in the MOTD points to the Fighter S wiki, which is a different game.
This is the correct Wiki.